### PR TITLE
BDC-16 Upgrade Build Image

### DIFF
--- a/cicd.template.yml
+++ b/cicd.template.yml
@@ -77,7 +77,7 @@ Resources:
       EncryptionKey: !ImportValue cfn-utilities:ArtifactKeyArn
       Environment:
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
         ComputeType: BUILD_GENERAL1_SMALL
         EnvironmentVariables:
           - Name: ARTIFACT_STORE


### PR DESCRIPTION
Upgrading the build image used for BDC Classes to Amazon Linux 2 Standard 3 for continued support